### PR TITLE
Fixing travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   - DJANGO_VERSION='>=1.8,<1.9'
   - DJANGO_VERSION='>=1.6,<1.7'
 install:
-  - "pip install Django==$DJANGO_VERSION"
+  - "pip install Django$DJANGO_VERSION"
   - "pip install -r tests_requirements.txt"
   - "python setup.py install"
   - "pip install coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: python
 python:
   - "2.7"
   - "3.3"
-install: 
+env:
+  - DJANGO_VERSION='>=1.8,<1.9'
+  - DJANGO_VERSION='>=1.6,<1.7'
+install:
+  - "pip install Django==$DJANGO_VERSION"
   - "pip install -r tests_requirements.txt"
   - "python setup.py install"
   - "pip install coveralls"

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,2 +1,2 @@
-Django==1.6.1
+Django
 fake-factory==0.3.2


### PR DESCRIPTION
There is an extra ```==``` in the travis instructions that make travis break with the following error:

```
ValueError: ('Expected version spec in', 'Django==>=1.8,<1.9', 'at', '==>=1.8,<1.9')
```