### PR TITLE
Tweaks to make the popit json importer handle popolo json from EP

### DIFF
--- a/popolo/importers/popit.py
+++ b/popolo/importers/popit.py
@@ -97,6 +97,15 @@ class PopItImporter(object):
                     area_id_to_django_object[area_id] = area
             return area
 
+        # Create all areas:
+        if 'areas' in data:
+            area_id_to_django_object = {}
+            for area_data in data['areas']:
+                with show_data_on_error('area_data', area_data):
+                    popit_id, area = \
+                        self.update_area(area_data)
+                    area_id_to_django_object[popit_id] = area
+
         # Do one pass through the organizations:
         org_id_to_django_object = {}
         for org_data in data['organizations']:
@@ -189,14 +198,15 @@ class PopItImporter(object):
             self.create_identifier('organization', org_data['id'], result)
 
         # Update other identifiers:
-        self.update_related_objects(
-            Organization,
-            self.get_popolo_model_class('Identifier'),
-            self.make_identifier_dict,
-            org_data['identifiers'],
-            result,
-            preserve_predicate=lambda i: i.scheme == 'popit-organization',
-        )
+        if 'identifiers' in org_data:
+            self.update_related_objects(
+                Organization,
+                self.get_popolo_model_class('Identifier'),
+                self.make_identifier_dict,
+                org_data['identifiers'],
+                result,
+                preserve_predicate=lambda i: i.scheme == 'popit-organization',
+            )
         # Update contact details:
         self.update_related_objects(
             Organization,
@@ -309,14 +319,15 @@ class PopItImporter(object):
             result
         )
         # Update other identifiers:
-        self.update_related_objects(
-            Person,
-            self.get_popolo_model_class('Identifier'),
-            self.make_identifier_dict,
-            person_data['identifiers'],
-            result,
-            preserve_predicate=lambda i: i.scheme == 'popit-person',
-        )
+        if 'identifiers' in person_data:
+            self.update_related_objects(
+                Person,
+                self.get_popolo_model_class('Identifier'),
+                self.make_identifier_dict,
+                person_data['identifiers'],
+                result,
+                preserve_predicate=lambda i: i.scheme == 'popit-person',
+            )
         # Update contact details:
         self.update_related_objects(
             Person,
@@ -352,6 +363,9 @@ class PopItImporter(object):
             person_id_to_django_object,
     ):
         Membership = self.get_popolo_model_class('Membership')
+        if 'id' not in membership_data:
+            membership_data['id'] = hash(str(membership_data)) # TODO rethink this line!
+
         existing = self.get_existing_django_object('membership', membership_data['id'])
         if existing is None:
             result = Membership()

--- a/popolo/importers/popit.py
+++ b/popolo/importers/popit.py
@@ -85,6 +85,7 @@ class PopItImporter(object):
         area_id_to_parent_area_id = {}
         def update_optional_area(object_data):
             area_data = object_data.get('area')
+            area_id = object_data.get('area_id')
             area = None
             if area_data:
                 if not area_data.get('id'):
@@ -95,6 +96,9 @@ class PopItImporter(object):
                 with show_data_on_error('area_data', area_data):
                     area_id, area = self.update_area(area_data)
                     area_id_to_django_object[area_id] = area
+            elif area_id:
+                #if we have an area_id instead of an inline area
+                area = self.get_existing_django_object('area', area_id)
             return area
 
         # Create all areas:

--- a/popolo/importers/popit.py
+++ b/popolo/importers/popit.py
@@ -100,6 +100,12 @@ class PopItImporter(object):
                 #if we have an area_id instead of an inline area
                 area = self.get_existing_django_object('area', area_id)
             return area
+        self.events = {}
+        # store events in a temp local dict:
+        if 'events' in data:
+            event_id_to_django_object = {}
+            for event_data in data['events']:
+                self.events[event_data['id']] = event_data
 
         # Create all areas:
         if 'areas' in data:
@@ -390,6 +396,11 @@ class PopItImporter(object):
         result.area = area
         result.start_date = membership_data.get('start_date', '')
         result.end_date = membership_data.get('end_date', '')
+        if 'legislative_period_id' in membership_data:
+            period_data = self.events[membership_data['legislative_period_id']]
+            result.start_date = period_data.get('start_date', '')
+            result.end_date = period_data.get('end_date', '')
+
         result.save()
         # Create an identifier with the PopIt ID:
         if not existing:

--- a/popolo/importers/popit.py
+++ b/popolo/importers/popit.py
@@ -109,12 +109,9 @@ class PopItImporter(object):
 
         # Create all areas:
         if 'areas' in data:
-            area_id_to_django_object = {}
             for area_data in data['areas']:
                 with show_data_on_error('area_data', area_data):
-                    popit_id, area = \
-                        self.update_area(area_data)
-                    area_id_to_django_object[popit_id] = area
+                    self.update_area(area_data)
 
         # Do one pass through the organizations:
         org_id_to_django_object = {}
@@ -372,8 +369,7 @@ class PopItImporter(object):
             post_id_to_django_object,
             person_id_to_django_object,
     ):
-        Membership = self.get_popolo_model_class('Membership')
-        if 'id' not in membership_data:
+        def generate_membership_id(membership_data):
             #construct an 'id' based on data that should be unique_together
             new_id = ''
             new_id += membership_data.get('legislative_period_id', 'missing') + "_"
@@ -382,9 +378,13 @@ class PopItImporter(object):
             new_id += membership_data.get('role', 'missing') + "_"
             new_id += membership_data.get('on_behalf_of_id', 'missing') + "_"
             new_id += membership_data.get('person_id', 'missing')
-            #consider hashing the id at this point?
+            return new_id
 
-            membership_data['id'] = new_id
+        Membership = self.get_popolo_model_class('Membership')
+
+        if 'id' not in membership_data:
+            membership_data['id'] = generate_membership_id(membership_data)
+
         existing = self.get_existing_django_object('membership', membership_data['id'])
         if existing is None:
             result = Membership()

--- a/popolo/importers/popit.py
+++ b/popolo/importers/popit.py
@@ -374,8 +374,17 @@ class PopItImporter(object):
     ):
         Membership = self.get_popolo_model_class('Membership')
         if 'id' not in membership_data:
-            membership_data['id'] = hash(str(membership_data)) # TODO rethink this line!
+            #construct an 'id' based on data that should be unique_together
+            new_id = ''
+            new_id += membership_data.get('legislative_period_id', 'missing') + "_"
+            new_id += membership_data.get('organization_id', 'missing') + "_"
+            new_id += membership_data.get('area_id', 'missing') + "_"
+            new_id += membership_data.get('role', 'missing') + "_"
+            new_id += membership_data.get('on_behalf_of_id', 'missing') + "_"
+            new_id += membership_data.get('person_id', 'missing')
+            #consider hashing the id at this point?
 
+            membership_data['id'] = new_id
         existing = self.get_existing_django_object('membership', membership_data['id'])
         if existing is None:
             result = Membership()


### PR DESCRIPTION
This is probably not yet ready to merge

-imports root level areas
-skips routines that use the missing `identifier` field
-generate an id for a membership... by hashing its stringified json (#TODO'd)