### PR TITLE
Fixes for whether existing Identifier objects are preserved or not

### DIFF
--- a/popolo/importers/popolo_json.py
+++ b/popolo/importers/popolo_json.py
@@ -278,14 +278,13 @@ class PopoloJSONImporter(object):
             self.create_identifier('organization', org_data['id'], result)
 
         # Update other identifiers:
-        if 'identifiers' in org_data:
-            self.update_related_objects(
-                Organization,
-                self.get_popolo_model_class('Identifier'),
-                self.make_identifier_dict,
-                org_data['identifiers'],
-                result,
-            )
+        self.update_related_objects(
+            Organization,
+            self.get_popolo_model_class('Identifier'),
+            self.make_identifier_dict,
+            org_data.get('identifiers', []),
+            result,
+        )
         # Update contact details:
         self.update_related_objects(
             Organization,
@@ -400,14 +399,13 @@ class PopoloJSONImporter(object):
             result
         )
         # Update other identifiers:
-        if 'identifiers' in person_data:
-            self.update_related_objects(
-                Person,
-                self.get_popolo_model_class('Identifier'),
-                self.make_identifier_dict,
-                person_data['identifiers'],
-                result,
-            )
+        self.update_related_objects(
+            Person,
+            self.get_popolo_model_class('Identifier'),
+            self.make_identifier_dict,
+            person_data.get('identifiers', []),
+            result,
+        )
         # Update contact details:
         self.update_related_objects(
             Person,

--- a/popolo/importers/popolo_json.py
+++ b/popolo/importers/popolo_json.py
@@ -74,7 +74,7 @@ class PopoloJSONImporter(object):
 
     TRUNCATE_OPTIONS = set(['yes', 'warn', 'exception'])
 
-    def __init__(self, id_prefix=None, truncate='exception'):
+    def __init__(self, id_prefix=None, truncate='exception', **kwargs):
         super(PopoloJSONImporter, self).__init__()
         if id_prefix is None:
             self.id_prefix = 'popit-'
@@ -92,7 +92,18 @@ class PopoloJSONImporter(object):
             'organization': {self.id_prefix + 'organization'},
             'area': {self.id_prefix + 'area'},
         }
+        # And if any extra ID schemes have been requested for
+        # preservation, keep them too:
+        if kwargs.get('id_schemes_to_preserve'):
+            self.add_id_schemes_to_preserve(kwargs['id_schemes_to_preserve'])
         self.observers = []
+
+    def add_id_schemes_to_preserve(self, id_schemes_to_preserve):
+        for collection, schemes in id_schemes_to_preserve.items():
+            if collection not in NEW_COLLECTIONS:
+                raise Exception("Unknown collection: '{}'".format(collection))
+            self.id_schemes_to_preserve.setdefault(collection, {})
+            self.id_schemes_to_preserve[collection].update(schemes)
 
     def add_observer(self, observer):
         self.observers.append(observer)


### PR DESCRIPTION
This pull request addresses two problems:

* The cases where a person's 'identifiers' array was missing and when
   it was empty had confusingly different behaviour. This makes the 'missing'
   case consistent with the empty array and existing handling of other related
   objects.
* It wasn't possible for users of the importer to specify particular schemes of
  identifiers that should be preserved; this pull request adds that facility.
