### PR TITLE
incompatibility with pa.org.za

### DIFF
--- a/popolo/importers/popolo_json.py
+++ b/popolo/importers/popolo_json.py
@@ -296,14 +296,24 @@ class PopoloJSONImporter(object):
             org_data.get('identifiers', []),
             result,
         )
+
         # Update contact details:
+        model_class = self.get_popolo_model_class('ContactDetail')
+        type_choices = model_class._meta.get_field('contact_type').choices
+        choice_values = [c[0].lower() for c in type_choices]
+        contact_details = org_data.get('contact_details', [])
+
+        def valid_filter(c):
+            return all(c['type'] in choice_values for c in c['contact_details'])
+        valid_contact_details = filter(valid_filter, contact_details)
         self.update_related_objects(
             Organization,
-            self.get_popolo_model_class('ContactDetail'),
+            model_class,
             self.make_contact_detail_dict,
-            org_data.get('contact_details', []),
+            valid_contact_details,
             result
         )
+
         # Update links:
         self.update_related_objects(
             Organization,
@@ -346,12 +356,21 @@ class PopoloJSONImporter(object):
         # Create an identifier with the PopIt ID:
         if not existing:
             self.create_identifier('post', post_data['id'], result)
+
         # Update contact details:
+        model_class = self.get_popolo_model_class('ContactDetail')
+        type_choices = model_class._meta.get_field('contact_type').choices
+        choice_values = [c[0].lower() for c in type_choices]
+        contact_details = post_data.get('contact_details', [])
+
+        def valid_filter(c):
+            return all(c['type'] in choice_values for c in c['contact_details'])
+        valid_contact_details = filter(valid_filter, contact_details)
         self.update_related_objects(
             Post,
-            self.get_popolo_model_class('ContactDetail'),
+            model_class,
             self.make_contact_detail_dict,
-            post_data.get('contact_details', []),
+            valid_contact_details,
             result
         )
         # Update links:
@@ -417,14 +436,24 @@ class PopoloJSONImporter(object):
             person_data.get('identifiers', []),
             result,
         )
+
         # Update contact details:
+        model_class = self.get_popolo_model_class('ContactDetail')
+        type_choices = model_class._meta.get_field('contact_type').choices
+        choice_values = [c[0].lower() for c in type_choices]
+        contact_details = person_data.get('contact_details', [])
+
+        def valid_filter(c):
+            return all(c['type'] in choice_values for c in c['contact_details'])
+        valid_contact_details = filter(valid_filter, contact_details)
         self.update_related_objects(
             Person,
-            self.get_popolo_model_class('ContactDetail'),
+            model_class,
             self.make_contact_detail_dict,
-            person_data.get('contact_details', []),
+            valid_contact_details,
             result
         )
+
         # Update links:
         self.update_related_objects(
             Person,
@@ -511,11 +540,19 @@ class PopoloJSONImporter(object):
             self.create_identifier('membership', membership_data['id'], result)
 
         # Update contact details:
+        model_class = self.get_popolo_model_class('ContactDetail')
+        type_choices = model_class._meta.get_field('contact_type').choices
+        choice_values = [c[0].lower() for c in type_choices]
+        contact_details = membership_data.get('contact_details', [])
+
+        def valid_filter(c):
+            return all(c['type'] in choice_values for c in c['contact_details'])
+        valid_contact_details = filter(valid_filter, contact_details)
         self.update_related_objects(
             Membership,
-            self.get_popolo_model_class('ContactDetail'),
+            model_class,
             self.make_contact_detail_dict,
-            membership_data.get('contact_details', []),
+            valid_contact_details,
             result
         )
         # Update links:

--- a/popolo/importers/popolo_json.py
+++ b/popolo/importers/popolo_json.py
@@ -303,8 +303,7 @@ class PopoloJSONImporter(object):
         choice_values = [c[0].lower() for c in type_choices]
         contact_details = org_data.get('contact_details', [])
 
-        def valid_filter(c):
-            return all(c['type'] in choice_values for c in c['contact_details'])
+        def valid_filter(c): return c['type'] in choice_values
         valid_contact_details = filter(valid_filter, contact_details)
         self.update_related_objects(
             Organization,
@@ -363,8 +362,7 @@ class PopoloJSONImporter(object):
         choice_values = [c[0].lower() for c in type_choices]
         contact_details = post_data.get('contact_details', [])
 
-        def valid_filter(c):
-            return all(c['type'] in choice_values for c in c['contact_details'])
+        def valid_filter(c): return c['type'] in choice_values
         valid_contact_details = filter(valid_filter, contact_details)
         self.update_related_objects(
             Post,
@@ -399,6 +397,9 @@ class PopoloJSONImporter(object):
             result = Person()
         else:
             result = existing
+        summary = person_data.get('summary')
+        if summary and len(summary) > 1024:
+            summary = summary[:1010] + "...(truncated)"
         self.set(result, 'name', person_data['name'])
         self.set(result, 'family_name', person_data.get('family_name') or '')
         self.set(result, 'given_name', person_data.get('given_name') or '')
@@ -411,7 +412,7 @@ class PopoloJSONImporter(object):
         self.set(result, 'gender', person_data.get('gender') or '')
         self.set(result, 'birth_date', person_data.get('birth_date') or '')
         self.set(result, 'death_date', person_data.get('death_date') or '')
-        self.set(result, 'summary', person_data.get('summary') or '')
+        self.set(result, 'summary', summary or '')
         self.set(result, 'biography', person_data.get('biography') or '')
         self.set(result, 'national_identity', person_data.get('national_identity') or None)
         self.set(result, 'image', person_data.get('image') or None)
@@ -443,8 +444,7 @@ class PopoloJSONImporter(object):
         choice_values = [c[0].lower() for c in type_choices]
         contact_details = person_data.get('contact_details', [])
 
-        def valid_filter(c):
-            return all(c['type'] in choice_values for c in c['contact_details'])
+        def valid_filter(c): return c['type'] in choice_values
         valid_contact_details = filter(valid_filter, contact_details)
         self.update_related_objects(
             Person,
@@ -545,8 +545,7 @@ class PopoloJSONImporter(object):
         choice_values = [c[0].lower() for c in type_choices]
         contact_details = membership_data.get('contact_details', [])
 
-        def valid_filter(c):
-            return all(c['type'] in choice_values for c in c['contact_details'])
+        def valid_filter(c): return c['type'] in choice_values
         valid_contact_details = filter(valid_filter, contact_details)
         self.update_related_objects(
             Membership,


### PR DESCRIPTION
Here are a couple of hacks I used to be able to import pa.org.za json.

- they use a contact detail postal_address which isn't in the spec and is too long for the type field (>12)
- they use a person summary longer than 1024 - couldn't see that this is defined by the spec but it is in the model and import test.

What do you think is the best way to handle these cases? I've just hacked this to get going with my project, but it'd be nice to find a more proper solution.

For context, I'd like to set up a popolo django app to use pa.org.za's data alongside other data from various sources for a slightly broader definition of politically-exposed persons in South Africa and present profiles of them including more sources than what pa.org.za uses. We'd like to pull People's Assembly's changes in daily so we'd consider pa.org.za authoritative for data we get from them.